### PR TITLE
[MA-170125] Update eventcard image scaling

### DIFF
--- a/Community/Components/EventComponents/EventCardBodyView.swift
+++ b/Community/Components/EventComponents/EventCardBodyView.swift
@@ -18,7 +18,7 @@ struct EventCardBodyView: View {
                                 imageSize = geometry.size
                             }
                     })
-                    .frame(height: (imageSize?.height ?? 0) > 500 ? 500 : nil)
+                    .frame(height: (imageSize?.height ?? 0) > 425 ? 425 : nil)
                     .clipped()
             } placeholder: {
                 ProgressView()

--- a/Community/Components/EventComponents/EventCardBodyView.swift
+++ b/Community/Components/EventComponents/EventCardBodyView.swift
@@ -1,23 +1,28 @@
 import SwiftUI
 
 struct EventCardBodyView: View {
-  let event: EventModel
+    let event: EventModel
 
-  var body: some View {
-    if let imageUrl = event.imageUrl {
-      CachedAsyncImage(url: imageUrl) { image in
-        image
-          .resizable()
-          .scaledToFit()
-          .frame(maxWidth: .infinity)
-          .frame(height: 300)
-          .clipped()
-          .opacity(event.hasEnded ? 0.6 : 1.0)
-      } placeholder: {
-        ProgressView()
-          .frame(maxWidth: .infinity)
-          .frame(height: 300)
-      }
+    @State private var imageSize: CGSize? = nil
+
+    var body: some View {
+        if let imageURL = event.imageUrl {
+            CachedAsyncImage(url: imageURL) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: .infinity, minHeight: 300)
+                    .background(GeometryReader { geometry in
+                        Color.clear
+                            .onAppear {
+                                imageSize = geometry.size
+                            }
+                    })
+                    .frame(height: (imageSize?.height ?? 0) > 500 ? 500 : nil)
+                    .clipped()
+            } placeholder: {
+                ProgressView()
+            }
     } else {
       defaultEventBackground(event: event)
         .frame(height: 300)


### PR DESCRIPTION
Updated event card to support cropping of pictures, and dynamic scaling Allowing images to have different heights in the event card.
<img width="368" alt="Screenshot 2025-01-17 at 14 06 35" src="https://github.com/user-attachments/assets/a3121843-26d7-49c8-9100-a597e946552e" /> <img width="368" alt="Screenshot 2025-01-17 at 14 06 04" src="https://github.com/user-attachments/assets/6ab067a9-a0c7-44e9-9e4d-519af59d2045" />
